### PR TITLE
l10n: TEAMS: Change the Korean team leader

### DIFF
--- a/po/TEAMS
+++ b/po/TEAMS
@@ -35,8 +35,8 @@ Members:	Stefano Lattarini <stefano.lattarini AT gmail.com>
 
 Language:	ko (Korean)
 Repository:	https://github.com/git-l10n-ko/git-l10n-ko/
-Leader:		Changwoo Ryu <cwryu@debian.org>
-Members:	Gwan-gyeong Mun <elongbug@gmail.com>
+Leader:		Gwan-gyeong Mun <elongbug@gmail.com>
+Members:	Changwoo Ryu <cwryu@debian.org>
 		Sihyeon Jang <uneedsihyeon@gmail.com>
 
 Language:	pt_PT (Portuguese - Portugal)


### PR DESCRIPTION
The Korean team leader has been taken over by Gwan-gyeong Mun.

Signed-off-by: Changwoo Ryu <cwryu@debian.org>
